### PR TITLE
add .mp4 extenstion to filename

### DIFF
--- a/chrome/getMP4.js
+++ b/chrome/getMP4.js
@@ -1,1 +1,1 @@
-var l = document.createElement('a'); l.href = document.querySelector('source').src; l.download = document.title; l.click();
+var l = document.createElement('a'); l.href = document.querySelector('source').src; l.download = document.title+'.mp4'; l.click();


### PR DESCRIPTION
If the title contains dots and then some other characters, the file wont download with the correct extension. This seems like the best solution.  
Example:
https://imgur.com/gallery/5f6K5G2

   